### PR TITLE
Handle both script and script setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,15 +16,16 @@ module.exports = function(content, options) {
 
   const result = compiler.parse(content, { sourceMap: false });
   const { styles, script, scriptSetup } = result.descriptor;
-  const usedScript = script || scriptSetup;
 
   const dependencies = [];
 
-  if (usedScript?.content) {
-    if (usedScript.attrs?.lang === 'ts') {
-      dependencies.push(...detectiveTypeScript(usedScript.content, options));
-    } else {
-      dependencies.push(...detectiveEs6(usedScript.content, options));
+  for (const usedScript of [script, scriptSetup]) {
+    if (usedScript?.content) {
+      if (usedScript.attrs?.lang === 'ts') {
+        dependencies.push(...detectiveTypeScript(usedScript.content, options));
+      } else {
+        dependencies.push(...detectiveEs6(usedScript.content, options));
+      }
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -51,4 +51,20 @@ import OtherComponent from "./OtherComponent.vue";
     assert.equal(deps[0], 'mylib');
     assert.equal(deps[1], './OtherComponent.vue');
   });
+
+  it('retrieves the dependencies of script block lang ts using both setup and normal syntax', () => {
+    const deps = detective(`<script lang="ts">
+import { foo, bar } from "mylib";
+</script>
+<script setup lang="ts">
+import OtherComponent from "./OtherComponent.vue";
+</script>
+<template>
+<OtherComponent />
+</template>
+`);
+    assert.equal(deps.length, 2);
+    assert.equal(deps[0], 'mylib');
+    assert.equal(deps[1], './OtherComponent.vue');
+  });
 });


### PR DESCRIPTION
#5 was a step in the right direction, but .vue files can have both `<script>` and `<script setup>`, so we need to check for dependencies from both of them.